### PR TITLE
Raise LazyPropertyError

### DIFF
--- a/mlworkflow/__init__.py
+++ b/mlworkflow/__init__.py
@@ -6,6 +6,6 @@ from .datasets import (AugmentedDataset, CachedDataset, Dataset, DictDataset,
     ExpandedDataset, PickledDataset, SqueezedDataset, TransformedDataset,
     chunkify, pickle_or_load, FilteredDataset)
 from .data_collection import DataCollection
-from .configurable import (Lazy, LazyConfigurable, lazyproperty,
-    cfg_call, exec_dict, exec_flat, flat_to_dict, get_callable)
+from .configurable import (Lazy, LazyConfigurable, LazyPropertyError,
+    lazyproperty, cfg_call, exec_dict, exec_flat, flat_to_dict, get_callable)
 from .visualization import array_to_rgba, arrays_to_rgba, palette

--- a/mlworkflow/configurable.py
+++ b/mlworkflow/configurable.py
@@ -14,6 +14,10 @@ class lazyproperty:
         return self.initializer(instance)
 
 
+class LazyPropertyError(Exception):
+    pass
+
+
 _NOVALUE = object()
 class _lazyproperty:
     """A placeholder here solely for the purpose of replacing potential class attributes
@@ -39,7 +43,10 @@ class _lazyproperty:
         # NOTE: __getattr__ is called twice if an AttributeError is raised
         # raising AttributeError is 50% slower, which is best ?
         # return instance.__getattr__(self.name)
-        raise AttributeError
+        try:
+            return instance.__getattr__(self.name)
+        except AttributeError:
+            raise LazyPropertyError(repr(self.name))
 
 
 class MetaLazy(type):


### PR DESCRIPTION
This is a proposition for wrapping AttributeError occuring inside lazy properties into another exception class, since propagation of AttributeError is stopped by Python the interpreter and this leads to misleading stack traces.