### PR TITLE
'terminate' ThreadPool instead of 'close' avoids error at SideRunnel.…

### DIFF
--- a/mlworkflow/misc.py
+++ b/mlworkflow/misc.py
@@ -125,5 +125,5 @@ class SideRunner:
             yield p
 
     def __del__(self):
-        self.pool.close()
+        self.pool.terminate()
         self.pool.join()


### PR DESCRIPTION
…__del__